### PR TITLE
Added grok-3 model

### DIFF
--- a/src/Enums/Model.php
+++ b/src/Enums/Model.php
@@ -14,6 +14,7 @@ enum Model: string
     case GROK_2_1212 = 'grok-2-1212';
     case GROK_2 = 'grok-2';
     case GROK_2_LATEST = 'grok-2-latest';
+    case GROK_3 = 'grok-3';
     case GROK_BETA = 'grok-beta';
 
     /**

--- a/src/Enums/Model.php
+++ b/src/Enums/Model.php
@@ -14,7 +14,7 @@ enum Model: string
     case GROK_2_1212 = 'grok-2-1212';
     case GROK_2 = 'grok-2';
     case GROK_2_LATEST = 'grok-2-latest';
-    case GROK_3 = 'grok-3';
+    case GROK_3 = 'grok-3-beta';
     case GROK_BETA = 'grok-beta';
 
     /**


### PR DESCRIPTION
While this change does not enable all of the grok3 features, it does allow chat completions to be used with the model due to enum restrictions at a PHP level.  It would be great to see this merged in and released as a minor release so those utilizing chat can update to the latest model.